### PR TITLE
Add Kaspersky OpenTIP scanner and provider selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/
 *.py[cod]
 .pytest_cache/
+secrets.toml
 

--- a/README.md
+++ b/README.md
@@ -33,11 +33,14 @@ headless = false        # show browser windows for debugging
 log_level = "DEBUG"     # logging verbosity
 wait_until = "domcontentloaded" # page load milestone for VirusTotal navigation
 providers = ["virustotal", "kaspersky"] # enabled reputation services
-kaspersky_token = ""   # optional API token for Kaspersky OpenTIP
+# API tokens can be supplied via secrets.toml (see secrets.toml.example)
+kaspersky_token = ""
 ```
 
 Adjust these values to change worker pool size, toggle headless mode, or modify log levels for all services. `wait_until` accepts
 any Playwright load milestone: `commit`, `domcontentloaded`, `load`, or `networkidle`.
+
+If present, `secrets.toml` overrides settings from `config.toml` and is ignored by git; copy `secrets.toml.example` and place your `kaspersky_token` there to keep credentials out of version control.
 
 ### API
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ starting Hypercorn so that Playwright can spawn browser subprocesses.
 
 Open <http://localhost:8000> and paste any text containing IOCs. The left pane auto-parses as you type (or after uploading a file) and the right pane groups supported IOCs (IPv4, FQDN, hashes). Each group provides its own **Scan** button, or use **Scan all** to submit everything. Scan results appear inline next to each IOC with icons and tags, and **Copy malicious** copies all detected malicious IOCs to your clipboard.
 
-Results are rendered inline with icons and a concise summary of VirusTotal reputation, detection counts, and any tags associated with the IOC.
+Use the **Provider** dropdown to select which reputation service to query. Results are rendered inline with icons and a concise summary of reputation, detection counts, and any tags associated with the IOC.
 
 ### Configuration
 

--- a/config.toml
+++ b/config.toml
@@ -2,3 +2,5 @@ worker_count = 2
 headless = false
 log_level = "DEBUG"
 wait_until = "domcontentloaded"
+providers = ["virustotal", "kaspersky"]
+kaspersky_token = ""

--- a/ioc_checker/config.py
+++ b/ioc_checker/config.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 import logging
 import tomllib
@@ -11,6 +11,8 @@ class Settings:
     headless: bool = False
     log_level: str = "DEBUG"
     wait_until: Literal["commit", "domcontentloaded", "load", "networkidle"] = "domcontentloaded"
+    providers: list[str] = field(default_factory=lambda: ["virustotal"])
+    kaspersky_token: str | None = None
 
 
 def load_settings() -> Settings:
@@ -21,6 +23,8 @@ def load_settings() -> Settings:
     valid = {"commit", "domcontentloaded", "load", "networkidle"}
     if data.get("wait_until") not in valid:
         data.pop("wait_until", None)
+    if not isinstance(data.get("providers"), list):
+        data.pop("providers", None)
     return Settings(**data)
 
 

--- a/ioc_checker/config.py
+++ b/ioc_checker/config.py
@@ -16,10 +16,15 @@ class Settings:
 
 
 def load_settings() -> Settings:
-    path = Path(__file__).resolve().parent.parent / "config.toml"
+    base = Path(__file__).resolve().parent.parent
+    path = base / "config.toml"
     data = {}
     if path.exists():
         data = tomllib.loads(path.read_text())
+    secret_path = base / "secrets.toml"
+    if secret_path.exists():
+        secrets = tomllib.loads(secret_path.read_text())
+        data.update(secrets)
     valid = {"commit", "domcontentloaded", "load", "networkidle"}
     if data.get("wait_until") not in valid:
         data.pop("wait_until", None)

--- a/ioc_checker/kaspersky.py
+++ b/ioc_checker/kaspersky.py
@@ -1,0 +1,85 @@
+from contextlib import asynccontextmanager
+from typing import Any, Dict, AsyncIterator
+import logging
+
+import httpx
+from iocparser import IOCParser
+
+from .config import settings
+
+logger = logging.getLogger(__name__)
+
+API_BASE = "https://opentip.kaspersky.com/api/v1"
+
+
+def classify_ioc(ioc: str) -> str:
+    parsed = IOCParser(ioc).parse()
+    if parsed:
+        kind = parsed[0].kind.lower()
+        if kind in {"ip", "ipv4", "ipv6"}:
+            return "ip"
+        if kind in {"md5", "sha1", "sha256", "sha512"}:
+            return "hash"
+        if kind == "url":
+            return "url"
+    return "domain"
+
+
+@asynccontextmanager
+async def get_context() -> AsyncIterator[httpx.AsyncClient]:
+    headers = {}
+    if settings.kaspersky_token:
+        headers["x-api-key"] = settings.kaspersky_token
+    async with httpx.AsyncClient(base_url=API_BASE, headers=headers, timeout=10) as client:
+        yield client
+
+
+async def lookup_hash(value: str, client: httpx.AsyncClient) -> Dict[str, Any]:
+    resp = await client.get("/search/hash", params={"request": value})
+    resp.raise_for_status()
+    return resp.json()
+
+
+async def lookup_ip(value: str, client: httpx.AsyncClient) -> Dict[str, Any]:
+    resp = await client.get("/search/ip", params={"request": value})
+    resp.raise_for_status()
+    return resp.json()
+
+
+async def lookup_domain(value: str, client: httpx.AsyncClient) -> Dict[str, Any]:
+    resp = await client.get("/search/domain", params={"request": value})
+    resp.raise_for_status()
+    return resp.json()
+
+
+async def lookup_url(value: str, client: httpx.AsyncClient) -> Dict[str, Any]:
+    resp = await client.get("/search/url", params={"request": value})
+    resp.raise_for_status()
+    return resp.json()
+
+
+async def submit_file(data: bytes, filename: str, client: httpx.AsyncClient) -> Dict[str, Any]:
+    files = {"file": (filename, data)}
+    resp = await client.post("/scan/file", files=files)
+    resp.raise_for_status()
+    return resp.json()
+
+
+async def get_file_report(task_id: str, client: httpx.AsyncClient) -> Dict[str, Any]:
+    resp = await client.get("/getresult/file", params={"task_id": task_id})
+    resp.raise_for_status()
+    return resp.json()
+
+
+async def fetch_ioc_info(ioc: str, client: httpx.AsyncClient) -> Dict[str, Any]:
+    ioc_type = classify_ioc(ioc)
+    logger.info("Fetching %s from Kaspersky", ioc)
+    if ioc_type == "hash":
+        data = await lookup_hash(ioc, client)
+    elif ioc_type == "ip":
+        data = await lookup_ip(ioc, client)
+    elif ioc_type == "url":
+        data = await lookup_url(ioc, client)
+    else:
+        data = await lookup_domain(ioc, client)
+    return {"ioc": ioc, "type": ioc_type, "data": data}

--- a/ioc_checker/kaspersky.py
+++ b/ioc_checker/kaspersky.py
@@ -1,5 +1,5 @@
 from contextlib import asynccontextmanager
-from typing import Any, Dict, AsyncIterator
+from typing import Any, Dict, AsyncIterator, Optional
 import logging
 
 import httpx
@@ -10,6 +10,16 @@ from .config import settings
 logger = logging.getLogger(__name__)
 
 API_BASE = "https://opentip.kaspersky.com/api/v1"
+
+ERROR_MAP = {
+    400: "incorrect query",
+    401: "user authentication failed",
+    403: "quota or request limit exceeded",
+    404: "lookup results not found",
+    413: "file size exceeds limit",
+    414: "web address length exceeds limit",
+    429: "too many requests",
+}
 
 
 def classify_ioc(ioc: str) -> str:
@@ -33,53 +43,156 @@ async def get_context() -> AsyncIterator[httpx.AsyncClient]:
     async with httpx.AsyncClient(base_url=API_BASE, headers=headers, timeout=10) as client:
         yield client
 
+def _parse_body(resp: httpx.Response) -> Optional[Any]:
+    ctype = resp.headers.get("content-type", "")
+    if "application/json" in ctype:
+        try:
+            return resp.json()
+        except Exception:  # pragma: no cover - defensive
+            return None
+    text = resp.text.strip()
+    return text or None
+
+
+def _handle_response(resp: httpx.Response) -> Dict[str, Any]:
+    body = _parse_body(resp)
+    if resp.status_code == 200:
+        return {"status_code": 200, "data": body}
+    if resp.status_code == 204:
+        return {"status_code": 204, "data": None}
+    message = ERROR_MAP.get(resp.status_code, resp.reason_phrase)
+    return {"status_code": resp.status_code, "error": message, "details": body}
+
+
+def _parse_hash(data: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "zone": data.get("Zone"),
+        "status": data.get("FileStatus"),
+        "sha1": data.get("Sha1"),
+        "md5": data.get("Md5"),
+        "sha256": data.get("Sha256"),
+        "first_seen": data.get("FirstSeen"),
+        "last_seen": data.get("LastSeen"),
+        "signer": data.get("Signer"),
+        "general_info": data.get("FileGeneralInfo"),
+    }
+
+
+def _parse_ip(data: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "zone": data.get("Zone"),
+        "status": data.get("Status"),
+        "ip": data.get("Ip"),
+        "country_code": data.get("CountryCode"),
+        "first_seen": data.get("FirstSeen"),
+        "hits_count": data.get("HitsCount"),
+        "categories": data.get("Categories"),
+        "general_info": data.get("IpGeneralInfo"),
+    }
+
+
+def _parse_domain(data: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "zone": data.get("Zone"),
+        "domain": data.get("Domain"),
+        "files_count": data.get("FilesCount"),
+        "urls_count": data.get("UrlsCount"),
+        "hits_count": data.get("HitsCount"),
+        "ipv4_count": data.get("Ipv4Count"),
+        "categories": data.get("Categories"),
+        "general_info": data.get("DomainGeneralInfo"),
+    }
+
+
+def _parse_url(data: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "zone": data.get("Zone"),
+        "url": data.get("Url"),
+        "host": data.get("Host"),
+        "ipv4_count": data.get("Ipv4Count"),
+        "files_count": data.get("FilesCount"),
+        "categories": data.get("Categories"),
+        "general_info": data.get("UrlGeneralInfo"),
+    }
+
+
+def _parse_file(data: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "zone": data.get("Zone"),
+        "status": data.get("FileStatus"),
+        "sha1": data.get("Sha1"),
+        "md5": data.get("Md5"),
+        "sha256": data.get("Sha256"),
+        "first_seen": data.get("FirstSeen"),
+        "last_seen": data.get("LastSeen"),
+        "signer": data.get("Signer"),
+        "packer": data.get("Packer"),
+        "size": data.get("Size"),
+        "type": data.get("Type"),
+        "hits_count": data.get("HitsCount"),
+        "general_info": data.get("FileGeneralInfo"),
+    }
+
 
 async def lookup_hash(value: str, client: httpx.AsyncClient) -> Dict[str, Any]:
     resp = await client.get("/search/hash", params={"request": value})
-    resp.raise_for_status()
-    return resp.json()
+    result = _handle_response(resp)
+    if "data" in result and result["data"]:
+        result["data"] = _parse_hash(result["data"])
+    return result
 
 
 async def lookup_ip(value: str, client: httpx.AsyncClient) -> Dict[str, Any]:
     resp = await client.get("/search/ip", params={"request": value})
-    resp.raise_for_status()
-    return resp.json()
+    result = _handle_response(resp)
+    if "data" in result and result["data"]:
+        result["data"] = _parse_ip(result["data"])
+    return result
 
 
 async def lookup_domain(value: str, client: httpx.AsyncClient) -> Dict[str, Any]:
     resp = await client.get("/search/domain", params={"request": value})
-    resp.raise_for_status()
-    return resp.json()
+    result = _handle_response(resp)
+    if "data" in result and result["data"]:
+        result["data"] = _parse_domain(result["data"])
+    return result
 
 
 async def lookup_url(value: str, client: httpx.AsyncClient) -> Dict[str, Any]:
     resp = await client.get("/search/url", params={"request": value})
-    resp.raise_for_status()
-    return resp.json()
+    result = _handle_response(resp)
+    if "data" in result and result["data"]:
+        result["data"] = _parse_url(result["data"])
+    return result
 
 
 async def submit_file(data: bytes, filename: str, client: httpx.AsyncClient) -> Dict[str, Any]:
     files = {"file": (filename, data)}
     resp = await client.post("/scan/file", files=files)
-    resp.raise_for_status()
-    return resp.json()
+    result = _handle_response(resp)
+    if "data" in result and result["data"]:
+        result["data"] = _parse_file(result["data"])
+    return result
 
 
 async def get_file_report(task_id: str, client: httpx.AsyncClient) -> Dict[str, Any]:
     resp = await client.get("/getresult/file", params={"task_id": task_id})
-    resp.raise_for_status()
-    return resp.json()
+    result = _handle_response(resp)
+    if "data" in result and result["data"]:
+        result["data"] = _parse_file(result["data"])
+    return result
 
 
 async def fetch_ioc_info(ioc: str, client: httpx.AsyncClient) -> Dict[str, Any]:
     ioc_type = classify_ioc(ioc)
     logger.info("Fetching %s from Kaspersky", ioc)
     if ioc_type == "hash":
-        data = await lookup_hash(ioc, client)
+        result = await lookup_hash(ioc, client)
     elif ioc_type == "ip":
-        data = await lookup_ip(ioc, client)
+        result = await lookup_ip(ioc, client)
     elif ioc_type == "url":
-        data = await lookup_url(ioc, client)
+        result = await lookup_url(ioc, client)
     else:
-        data = await lookup_domain(ioc, client)
-    return {"ioc": ioc, "type": ioc_type, "data": data}
+        result = await lookup_domain(ioc, client)
+    result.update({"ioc": ioc, "type": ioc_type})
+    return result

--- a/ioc_checker/main.py
+++ b/ioc_checker/main.py
@@ -35,7 +35,7 @@ KIND_MAP = {
 
 class ScanRequest(BaseModel):
     iocs: list[str]
-    service: str = "virustotal"
+    service: str = settings.providers[0]
 
 
 class ParseRequest(BaseModel):

--- a/ioc_checker/main.py
+++ b/ioc_checker/main.py
@@ -56,7 +56,9 @@ templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
 @app.get("/", response_class=HTMLResponse)
 async def index(request: Request) -> HTMLResponse:
-    return templates.TemplateResponse("index.html", {"request": request})
+    return templates.TemplateResponse(
+        "index.html", {"request": request, "providers": settings.providers}
+    )
 
 @app.post("/parse")
 async def parse_iocs(req: ParseRequest) -> dict[str, list[str]]:

--- a/ioc_checker/queue.py
+++ b/ioc_checker/queue.py
@@ -4,11 +4,13 @@ from dataclasses import dataclass
 from typing import Dict, Optional
 import logging
 
+from .config import settings
+
 @dataclass
 class Task:
     id: str
     ioc: str
-    service: str = "virustotal"
+    service: str = settings.providers[0]
     status: str = "queued"  # queued, processing, done, error
     result: Optional[dict] = None
     error: Optional[str] = None
@@ -20,7 +22,7 @@ queue: asyncio.Queue[str] = asyncio.Queue()
 logger = logging.getLogger(__name__)
 
 
-async def add_task(ioc: str, service: str = "virustotal") -> str:
+async def add_task(ioc: str, service: str = settings.providers[0]) -> str:
     task_id = str(uuid.uuid4())
     task = Task(id=task_id, ioc=ioc, service=service)
     _tasks[task_id] = task

--- a/ioc_checker/templates/index.html
+++ b/ioc_checker/templates/index.html
@@ -198,12 +198,27 @@ function poll(id, statusElem){
             statusElem.innerHTML = '<span class="icon"><i class="fas fa-spinner fa-spin"></i></span>';
             setTimeout(() => poll(id, statusElem), 1000);
         }else if(data.status === 'done'){
-            const stats = data.result.last_analysis_stats || {};
-            const total = Object.values(stats).reduce((a,b)=>a+b,0);
-            const mal = stats.malicious || 0;
-            const tags = data.result.tags && data.result.tags.length ? ` <span class="icon"><i class="fas fa-tags"></i></span> ${data.result.tags.join(', ')}` : '';
-            if(mal > 0) statusElem.dataset.malicious = 'true';
-            statusElem.innerHTML = `<span class="icon has-text-success"><i class="fas fa-check"></i></span> rep ${data.result.reputation}, ${mal}/${total} detections${tags}`;
+            if(data.service === 'kaspersky'){
+                const info = data.result || {};
+                if(info.status_code !== 200){
+                    statusElem.innerHTML = `<span class="icon has-text-danger"><i class="fas fa-exclamation-triangle"></i></span> ${info.error || 'error'}`;
+                    return;
+                }
+                const res = info.data || {};
+                let text = `zone ${res.zone || 'unknown'}`;
+                if(res.status) text += `, status ${res.status}`;
+                if(typeof res.hits_count === 'number') text += `, hits ${res.hits_count}`;
+                if(res.categories && res.categories.length) text += `, categories ${res.categories.join(', ')}`;
+                if(res.zone && res.zone.toLowerCase() !== 'green') statusElem.dataset.malicious = 'true';
+                statusElem.innerHTML = `<span class="icon has-text-success"><i class="fas fa-check"></i></span> ${text}`;
+            }else{
+                const stats = data.result.last_analysis_stats || {};
+                const total = Object.values(stats).reduce((a,b)=>a+b,0);
+                const mal = stats.malicious || 0;
+                const tags = data.result.tags && data.result.tags.length ? ` <span class="icon"><i class="fas fa-tags"></i></span> ${data.result.tags.join(', ')}` : '';
+                if(mal > 0) statusElem.dataset.malicious = 'true';
+                statusElem.innerHTML = `<span class="icon has-text-success"><i class="fas fa-check"></i></span> rep ${data.result.reputation}, ${mal}/${total} detections${tags}`;
+            }
         }else if(data.status === 'error'){
             statusElem.innerHTML = `<span class="icon has-text-danger"><i class="fas fa-exclamation-triangle"></i></span> error`;
         }

--- a/ioc_checker/templates/index.html
+++ b/ioc_checker/templates/index.html
@@ -69,6 +69,18 @@
                 <textarea id="raw-input" class="textarea" placeholder="Paste text containing IOCs"></textarea>
             </div>
         </div>
+        <div class="field">
+            <label class="label has-text-light">Provider</label>
+            <div class="control">
+                <div class="select is-fullwidth">
+                    <select id="provider">
+                        {% for p in providers %}
+                        <option value="{{p}}">{{p}}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+            </div>
+        </div>
         <div class="field is-grouped">
             <div class="control">
                 <button class="button is-link" id="scan-all">Scan all</button>
@@ -83,6 +95,8 @@
 
 <script>
 let parsedData = {};
+
+document.getElementById('provider').addEventListener('change', renderParsed);
 
 const fileInput = document.getElementById('file-input');
 document.getElementById('upload-btn').addEventListener('click', () => fileInput.click());
@@ -118,11 +132,12 @@ function renderParsed(){
         title.textContent = kind;
         box.appendChild(title);
         const list = document.createElement('div');
+        const provider = document.getElementById('provider').value;
         values.forEach(val => {
             const item = document.createElement('div');
             item.className = 'ioc-item';
             const link = document.createElement('a');
-            link.href = vtLink(kind,val);
+            link.href = iocLink(provider, kind, val);
             link.target = '_blank';
             link.textContent = val;
             item.appendChild(link);
@@ -141,7 +156,10 @@ function renderParsed(){
     });
 }
 
-function vtLink(kind, value){
+function iocLink(provider, kind, value){
+    if(provider === 'kaspersky'){
+        return `https://opentip.kaspersky.com/${value}`;
+    }
     if(kind === 'ipv4') return `https://www.virustotal.com/gui/ip-address/${value}`;
     if(kind === 'fqdn') return `https://www.virustotal.com/gui/domain/${value}`;
     return `https://www.virustotal.com/gui/file/${value}`;
@@ -149,7 +167,8 @@ function vtLink(kind, value){
 
 function scan(iocs){
     if(!iocs.length) return;
-    fetch('/scan', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({service:'virustotal', iocs})})
+    const service = document.getElementById('provider').value;
+    fetch('/scan', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({service, iocs})})
         .then(r => r.json())
         .then(data => {
             data.tasks.forEach(t => {

--- a/secrets.toml.example
+++ b/secrets.toml.example
@@ -1,0 +1,2 @@
+# Copy to secrets.toml and fill in your API tokens
+kaspersky_token = ""

--- a/tests/test_config_secrets.py
+++ b/tests/test_config_secrets.py
@@ -1,0 +1,15 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+
+from ioc_checker.config import load_settings
+
+
+def test_secrets_override():
+    root = pathlib.Path(__file__).resolve().parent.parent
+    secret = root / "secrets.toml"
+    secret.write_text('kaspersky_token = "secret"\n')
+    try:
+        s = load_settings()
+        assert s.kaspersky_token == "secret"
+    finally:
+        secret.unlink()

--- a/tests/test_kaspersky_api.py
+++ b/tests/test_kaspersky_api.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import sys, pathlib
 sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
 import httpx
@@ -74,3 +75,28 @@ def test_submit_file_parsing():
     assert res["status_code"] == 200
     assert res["data"]["status"] == "Adware and other"
     assert res["data"]["size"] == 100
+
+
+def test_lookup_ip_with_text_body():
+    sample = {
+        "Zone": "Green",
+        "Status": "Clean",
+        "Ip": "1.2.3.4",
+    }
+
+    async def handler(request):
+        return httpx.Response(
+            200,
+            text=json.dumps(sample),
+            headers={"content-type": "text/plain"},
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    async def main():
+        async with httpx.AsyncClient(transport=transport, base_url=kaspersky.API_BASE) as client:
+            return await kaspersky.lookup_ip("1.2.3.4", client)
+
+    res = run(main())
+    assert res["status_code"] == 200
+    assert res["data"]["ip"] == "1.2.3.4"

--- a/tests/test_kaspersky_api.py
+++ b/tests/test_kaspersky_api.py
@@ -1,0 +1,76 @@
+import asyncio
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+import httpx
+from ioc_checker import kaspersky
+
+
+def run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def test_lookup_hash_parsing():
+    sample = {
+        "Zone": "Green",
+        "FileStatus": "Clean",
+        "Sha1": "abc",
+        "Md5": "def",
+        "Sha256": "ghi",
+    }
+
+    async def handler(request):
+        assert request.url.path == "/api/v1/search/hash"
+        return httpx.Response(200, json=sample)
+
+    transport = httpx.MockTransport(handler)
+
+    async def main():
+        async with httpx.AsyncClient(transport=transport, base_url=kaspersky.API_BASE) as client:
+            return await kaspersky.lookup_hash("abc", client)
+
+    res = run(main())
+    assert res["status_code"] == 200
+    assert res["data"]["zone"] == "Green"
+    assert res["data"]["sha256"] == "ghi"
+
+
+def test_lookup_url_error():
+    async def handler(request):
+        return httpx.Response(414, json={"message": "too long"})
+
+    transport = httpx.MockTransport(handler)
+
+    async def main():
+        async with httpx.AsyncClient(transport=transport, base_url=kaspersky.API_BASE) as client:
+            return await kaspersky.lookup_url("x" * 2001, client)
+
+    res = run(main())
+    assert res["status_code"] == 414
+    assert res["error"] == kaspersky.ERROR_MAP[414]
+
+
+def test_submit_file_parsing():
+    sample = {
+        "Zone": "Yellow",
+        "FileStatus": "Adware and other",
+        "Sha1": "aaa",
+        "Md5": "bbb",
+        "Sha256": "ccc",
+        "Size": 100,
+        "Type": "exe",
+    }
+
+    async def handler(request):
+        assert request.url.path == "/api/v1/scan/file"
+        return httpx.Response(200, json=sample)
+
+    transport = httpx.MockTransport(handler)
+
+    async def main():
+        async with httpx.AsyncClient(transport=transport, base_url=kaspersky.API_BASE) as client:
+            return await kaspersky.submit_file(b"data", "file.bin", client)
+
+    res = run(main())
+    assert res["status_code"] == 200
+    assert res["data"]["status"] == "Adware and other"
+    assert res["data"]["size"] == 100


### PR DESCRIPTION
## Summary
- integrate Kaspersky OpenTIP API with lookup helpers for IPs, domains, URLs, hashes, and file scans
- allow selecting reputation service providers via config and worker update
- document provider configuration and test using Kaspersky only

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6dac785348333b726d1919e6a4db7