### PR TITLE
Remove VirusTotal references from UI and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # IOC Checker with Playwright
 
-This project demonstrates a small microservice-style application that accepts Indicators of Compromise (IOCs) and fetches their reputations from services such as VirusTotal and Kaspersky OpenTIP. VirusTotal lookups are performed via [Playwright](https://playwright.dev) while Kaspersky requests use the official REST API. Parsing of IOCs relies on the [iocparser](https://pypi.org/project/iocparser/) library.
+This project demonstrates a small microservice-style application that accepts Indicators of Compromise (IOCs) and fetches their reputations from services such as Kaspersky OpenTIP. Kaspersky requests use the official REST API. Parsing of IOCs relies on the [iocparser](https://pypi.org/project/iocparser/) library.
 
 ## Components
 
 - **FastAPI web UI** – parse and submit IOCs with progress updates.
-- **Worker** – consumes a queue and performs lookups against the configured providers (VirusTotal via Playwright, Kaspersky OpenTIP via HTTP API).
+- **Worker** – consumes a queue and performs lookups against the configured providers (e.g., Kaspersky OpenTIP via HTTP API).
 - **Queue** – in-memory task queue coordinating the two components.
 
 ## Running
@@ -31,8 +31,8 @@ Runtime options live in `config.toml`:
 worker_count = 2        # number of worker tasks
 headless = false        # show browser windows for debugging
 log_level = "DEBUG"     # logging verbosity
-wait_until = "domcontentloaded" # page load milestone for VirusTotal navigation
-providers = ["virustotal", "kaspersky"] # enabled reputation services
+wait_until = "domcontentloaded" # page load milestone for browser automation
+providers = ["kaspersky"] # enabled reputation services
 # API tokens can be supplied via secrets.toml (see secrets.toml.example)
 kaspersky_token = ""
 ```
@@ -46,7 +46,7 @@ If present, `secrets.toml` overrides settings from `config.toml` and is ignored 
 
 - `POST /parse` – body `{ "text": "..." }` returns detected IOCs grouped by type.
 - `POST /parse-file` – multipart upload of a text-based file (`.txt`, `.log`, `.csv`, `.json`) returning detected IOCs.
-- `POST /scan` – body `{ "service": "virustotal" | "kaspersky", "iocs": ["..."] }` queues IOCs for the specified service.
+- `POST /scan` – body `{ "service": "kaspersky", "iocs": ["..."] }` queues IOCs for the specified service.
 - `GET /status/{id}` – retrieve task progress and results.
 
 ## Notes

--- a/ioc_checker/config.py
+++ b/ioc_checker/config.py
@@ -11,7 +11,7 @@ class Settings:
     headless: bool = False
     log_level: str = "DEBUG"
     wait_until: Literal["commit", "domcontentloaded", "load", "networkidle"] = "domcontentloaded"
-    providers: list[str] = field(default_factory=lambda: ["virustotal"])
+    providers: list[str] = field(default_factory=lambda: ["kaspersky"])
     kaspersky_token: str | None = None
     database_url: str = "sqlite+aiosqlite:///./cache.db"
 

--- a/ioc_checker/templates/index.html
+++ b/ioc_checker/templates/index.html
@@ -160,9 +160,7 @@ function iocLink(provider, kind, value){
     if(provider === 'kaspersky'){
         return `https://opentip.kaspersky.com/${value}`;
     }
-    if(kind === 'ipv4') return `https://www.virustotal.com/gui/ip-address/${value}`;
-    if(kind === 'fqdn') return `https://www.virustotal.com/gui/domain/${value}`;
-    return `https://www.virustotal.com/gui/file/${value}`;
+    return '#';
 }
 
 function scan(iocs){
@@ -212,12 +210,7 @@ function poll(id, statusElem){
                 if(res.zone && res.zone.toLowerCase() !== 'green') statusElem.dataset.malicious = 'true';
                 statusElem.innerHTML = `<span class="icon has-text-success"><i class="fas fa-check"></i></span> ${text}`;
             }else{
-                const stats = data.result.last_analysis_stats || {};
-                const total = Object.values(stats).reduce((a,b)=>a+b,0);
-                const mal = stats.malicious || 0;
-                const tags = data.result.tags && data.result.tags.length ? ` <span class="icon"><i class="fas fa-tags"></i></span> ${data.result.tags.join(', ')}` : '';
-                if(mal > 0) statusElem.dataset.malicious = 'true';
-                statusElem.innerHTML = `<span class="icon has-text-success"><i class="fas fa-check"></i></span> rep ${data.result.reputation}, ${mal}/${total} detections${tags}`;
+                statusElem.innerHTML = `<span class="icon has-text-danger"><i class="fas fa-exclamation-triangle"></i></span> unsupported service`;
             }
         }else if(data.status === 'error'){
             statusElem.innerHTML = `<span class="icon has-text-danger"><i class="fas fa-exclamation-triangle"></i></span> error`;


### PR DESCRIPTION
## Summary
- drop VirusTotal from UI and documentation
- default to Kaspersky provider in configuration
- simplify frontend polling and linking for Kaspersky-only

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7e8ee15a08333a0e7a5d58e75d17d