### PR TITLE
Revamp UI and status logic

### DIFF
--- a/ioc_checker/templates/index.html
+++ b/ioc_checker/templates/index.html
@@ -3,95 +3,114 @@
 <head>
     <meta charset="utf-8" />
     <title>IOC Checker</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulmaswatch@0.8.1/darkly/bulmaswatch.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <style>
         html, body {
             height: 100%;
+            margin: 0;
         }
 
         body {
-            padding: 1rem;
-        }
-
-        #app-columns {
-            height: calc(100vh - 2rem);
+            display: flex;
+            background: #121212;
+            color: #eee;
+            font-family: Arial, sans-serif;
         }
 
         #input-column {
-            flex: 0 0 30%;
-            max-width: 30%;
+            width: 30%;
             padding: 1rem;
+            box-sizing: border-box;
+            border-right: 1px solid #333;
             overflow-y: auto;
-            background-color: #1e1e1e;
-            border-right: 1px solid #2e2e2e;
         }
 
         #ioc-columns {
-            flex: 0 0 70%;
-            max-width: 70%;
+            flex: 1;
             padding: 1rem;
+            box-sizing: border-box;
             overflow-y: auto;
-            background-color: #181818;
         }
 
-        textarea.textarea {
-            background-color: #2b2b2b;
-            color: #f5f5f5;
-            border-color: #444;
+        textarea {
+            width: 100%;
+            min-height: 150px;
+            background: #1e1e1e;
+            color: #eee;
+            border: 1px solid #333;
+            padding: 0.5rem;
+            box-sizing: border-box;
         }
 
-        textarea.textarea:focus {
-            border-color: #7957d5;
-            box-shadow: 0 0 0 0.125em rgba(121, 87, 213, 0.25);
+        button, select {
+            background: #333;
+            color: #eee;
+            border: 1px solid #555;
+            padding: 0.5rem;
+            cursor: pointer;
         }
 
-        textarea.textarea::placeholder {
-            color: #7a7a7a;
+        button {
+            margin-top: 0.5rem;
+        }
+
+        .ioc-item {
+            display: flex;
+            align-items: center;
+            padding: 4px 0;
+            border-bottom: 1px solid #222;
+        }
+
+        .ioc-item .status {
+            width: 20px;
+            text-align: center;
+            margin-right: 6px;
+            color: #999;
+        }
+
+        .ioc-item .ioc-value {
+            margin-right: 6px;
+        }
+
+        .ioc-item .links a {
+            margin-left: 4px;
+            color: #ccc;
+        }
+
+        .ioc-item .links a:hover {
+            color: #fff;
+        }
+
+        .ioc-item .result {
+            margin-left: auto;
+            font-size: 0.9em;
         }
     </style>
 </head>
-<body class="has-background-dark has-text-light">
-<div class="columns is-gapless" id="app-columns">
-    <div class="column" id="input-column">
-        <h1 class="title has-text-light">IOC Checker</h1>
-        <div class="field">
-            <div class="control">
-                <button class="button is-primary" id="upload-btn">
-                    <span class="icon"><i class="fas fa-upload"></i></span>
-                    <span>Upload file</span>
-                </button>
-                <input class="is-hidden" type="file" id="file-input" accept=".txt,.log,.csv,.json">
-            </div>
-        </div>
-        <div class="field">
-            <div class="control">
-                <textarea id="raw-input" class="textarea" placeholder="Paste text containing IOCs"></textarea>
-            </div>
-        </div>
-        <div class="field">
-            <label class="label has-text-light">Provider</label>
-            <div class="control">
-                <div class="select is-fullwidth">
-                    <select id="provider">
-                        {% for p in providers %}
-                        <option value="{{p}}">{{p}}</option>
-                        {% endfor %}
-                    </select>
-                </div>
-            </div>
-        </div>
-        <div class="field is-grouped">
-            <div class="control">
-                <button class="button is-link" id="scan-all">Scan all</button>
-            </div>
-            <div class="control">
-                <button class="button" id="copy-malicious">Copy malicious</button>
-            </div>
-        </div>
+<body>
+<div id="input-column">
+    <h1>IOC Checker</h1>
+    <div>
+        <button id="upload-btn"><i class="fas fa-upload"></i> Upload file</button>
+        <input type="file" id="file-input" accept=".txt,.log,.csv,.json" style="display:none">
     </div>
-    <div class="column" id="ioc-columns"></div>
+    <div>
+        <textarea id="raw-input" placeholder="Paste text containing IOCs"></textarea>
+    </div>
+    <div>
+        <label for="provider">Provider</label>
+        <select id="provider">
+            {% for p in providers %}
+            <option value="{{p}}">{{p}}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div>
+        <button id="scan-all">Scan all</button>
+        <button id="copy-malicious">Copy malicious</button>
+    </div>
 </div>
+<div id="ioc-columns"></div>
 
 <script>
 let parsedData = {};
@@ -125,44 +144,55 @@ function renderParsed(){
     const container = document.getElementById('ioc-columns');
     container.innerHTML = '';
     Object.entries(parsedData).forEach(([kind, values]) => {
-        const box = document.createElement('div');
-        box.className = 'box';
+        const section = document.createElement('div');
         const title = document.createElement('h3');
-        title.className = 'subtitle';
         title.textContent = kind;
-        box.appendChild(title);
-        const list = document.createElement('div');
-        const provider = document.getElementById('provider').value;
+        section.appendChild(title);
         values.forEach(val => {
             const item = document.createElement('div');
             item.className = 'ioc-item';
-            const link = document.createElement('a');
-            link.href = iocLink(provider, kind, val);
-            link.target = '_blank';
-            link.textContent = val;
-            item.appendChild(link);
+            item.dataset.value = val;
+
             const status = document.createElement('span');
-            status.className = 'status ml-2';
+            status.className = 'status';
+            status.innerHTML = '<i class="fas fa-question"></i>';
             item.appendChild(status);
-            list.appendChild(item);
+
+            const valueSpan = document.createElement('span');
+            valueSpan.className = 'ioc-value';
+            valueSpan.textContent = val;
+            item.appendChild(valueSpan);
+
+            const links = document.createElement('span');
+            links.className = 'links';
+            const vt = document.createElement('a');
+            vt.href = `https://www.virustotal.com/gui/search/${encodeURIComponent(val)}`;
+            vt.target = '_blank';
+            vt.innerHTML = '<i class="fas fa-virus"></i>';
+            links.appendChild(vt);
+            if(SCANNABLE.includes(kind)){
+                const kas = document.createElement('a');
+                kas.href = `https://opentip.kaspersky.com/${val}`;
+                kas.target = '_blank';
+                kas.innerHTML = '<i class="fas fa-shield-halved"></i>';
+                links.appendChild(kas);
+            }
+            item.appendChild(links);
+
+            const result = document.createElement('span');
+            result.className = 'result';
+            item.appendChild(result);
+
+            section.appendChild(item);
         });
-        box.appendChild(list);
         if(SCANNABLE.includes(kind)){
             const btn = document.createElement('button');
-            btn.className = 'button is-small is-link mt-2';
             btn.textContent = 'Scan';
             btn.addEventListener('click', () => scan(values));
-            box.appendChild(btn);
+            section.appendChild(btn);
         }
-        container.appendChild(box);
+        container.appendChild(section);
     });
-}
-
-function iocLink(provider, kind, value){
-    if(provider === 'kaspersky' && SCANNABLE.includes(kind)){
-        return `https://opentip.kaspersky.com/${value}`;
-    }
-    return '#';
 }
 
 function scan(iocs){
@@ -172,8 +202,8 @@ function scan(iocs){
         .then(r => r.json())
         .then(data => {
             data.tasks.forEach(t => {
-                const elem = [...document.querySelectorAll('.ioc-item')].find(div => div.firstChild.textContent === t.ioc);
-                if(elem) poll(t.id, elem.querySelector('.status'));
+                const elem = [...document.querySelectorAll('.ioc-item')].find(div => div.dataset.value === t.ioc);
+                if(elem) poll(t.id, elem.querySelector('.status'), elem.querySelector('.result'));
             });
         });
 }
@@ -188,20 +218,23 @@ document.getElementById('scan-all').addEventListener('click', () => {
 
 document.getElementById('copy-malicious').addEventListener('click', () => {
     const mal = [...document.querySelectorAll('.status[data-malicious="true"]')]
-        .map(s => s.parentElement.querySelector('a').textContent);
+        .map(s => s.parentElement.querySelector('.ioc-value').textContent);
     if(mal.length) navigator.clipboard.writeText(mal.join('\n'));
 });
 
-function poll(id, statusElem){
+function poll(id, statusElem, resultElem){
     fetch(`/status/${id}`).then(r => r.json()).then(data => {
         if(data.status === 'queued' || data.status === 'processing'){
-            statusElem.innerHTML = '<span class="icon"><i class="fas fa-spinner fa-spin"></i></span>';
-            setTimeout(() => poll(id, statusElem), 1000);
+            statusElem.innerHTML = '<i class="fas fa-spinner fa-spin"></i>';
+            statusElem.style.color = '#999';
+            setTimeout(() => poll(id, statusElem, resultElem), 1000);
         }else if(data.status === 'done'){
             if(data.service === 'kaspersky'){
                 const info = data.result || {};
                 if(info.status_code !== 200){
-                    statusElem.innerHTML = `<span class="icon has-text-danger"><i class="fas fa-exclamation-triangle"></i></span> ${info.error || 'error'}`;
+                    statusElem.innerHTML = '<i class="fas fa-times"></i>';
+                    statusElem.style.color = '#e74c3c';
+                    resultElem.textContent = info.error || 'error';
                     return;
                 }
                 const res = info.data || {};
@@ -210,15 +243,22 @@ function poll(id, statusElem){
                 if(typeof res.hits_count === 'number') text += `, hits ${res.hits_count}`;
                 if(res.categories && res.categories.length) text += `, categories ${res.categories.join(', ')}`;
                 if(res.zone && res.zone.toLowerCase() !== 'green') statusElem.dataset.malicious = 'true';
-                statusElem.innerHTML = `<span class="icon has-text-success"><i class="fas fa-check"></i></span> ${text}`;
+                statusElem.innerHTML = '<i class="fas fa-check"></i>';
+                statusElem.style.color = '#4caf50';
+                resultElem.textContent = text;
             }else{
-                statusElem.innerHTML = `<span class="icon has-text-danger"><i class="fas fa-exclamation-triangle"></i></span> unsupported service`;
+                statusElem.innerHTML = '<i class="fas fa-times"></i>';
+                statusElem.style.color = '#e74c3c';
+                resultElem.textContent = 'unsupported service';
             }
         }else if(data.status === 'error'){
-            statusElem.innerHTML = `<span class="icon has-text-danger"><i class="fas fa-exclamation-triangle"></i></span> error`;
+            statusElem.innerHTML = '<i class="fas fa-times"></i>';
+            statusElem.style.color = '#e74c3c';
+            resultElem.textContent = 'error';
         }
     });
 }
 </script>
 </body>
 </html>
+

--- a/ioc_checker/templates/index.html
+++ b/ioc_checker/templates/index.html
@@ -137,9 +137,9 @@ const RESULT_PARSERS = {
         const parts = [];
         if(res.zone) parts.push(`<span><i class="fas fa-shield-halved"></i> ${res.zone}</span>`);
 
-        Object.entries({files_count:'fa-file', urls_count:'fa-link', hits_count:'fa-bolt', ipv4_count:'fa-network-wired'}).forEach(([key, icon]) => {
+        Object.entries({files_count:'fa-file', urls_count:'fa-link', hits_count:'fa-bolt', ipv4_count:'fa-network-wired', first_seen:'fa-calendar-plus'}).forEach(([key, icon]) => {
             const val = res[key];
-            if(typeof val === 'number') parts.push(`<span><i class="fas ${icon}"></i> ${val}</span>`);
+            if(val !== undefined && val !== null) parts.push(`<span><i class="fas ${icon}"></i> ${short(val)}</span>`);
         });
 
         const iconMap = {
@@ -148,7 +148,6 @@ const RESULT_PARSERS = {
             Size: 'fa-weight-hanging',
             HitsCount: 'fa-bolt',
             FirstSeen: 'fa-calendar-plus',
-            LastSeen: 'fa-calendar-minus',
             Sha256: 'fa-fingerprint',
             Sha1: 'fa-fingerprint',
             Md5: 'fa-fingerprint',
@@ -158,7 +157,7 @@ const RESULT_PARSERS = {
         };
 
         const gen = res.general_info || {};
-        const skipKeys = new Set(['Domain','CategoriesWithZone','Sha1','Sha256','Md5','Sha512']);
+        const skipKeys = new Set(['Domain','CategoriesWithZone','Sha1','Sha256','Md5','Sha512','FirstSeen','LastSeen']);
         Object.entries(gen).forEach(([key, val]) => {
             if(val === null || skipKeys.has(key)) return;
             if(key === 'Categories' && Array.isArray(val) && val.length){
@@ -167,6 +166,10 @@ const RESULT_PARSERS = {
                     parts.push(`<span><i class="fas fa-tag"></i> ${short(cat)}</span>`);
                 });
                 return;
+            }
+            if(typeof val === 'number' && key === 'Size'){
+                const mb = (val / (1024*1024)).toFixed(2).replace('.', ',');
+                val = `${mb} Mb`;
             }
             if(typeof val === 'string' || typeof val === 'number'){
                 const icon = iconMap[key] || 'fa-circle';

--- a/ioc_checker/templates/index.html
+++ b/ioc_checker/templates/index.html
@@ -116,6 +116,37 @@
 let parsedData = {};
 const SCANNABLE = ['ipv4','ipv6','fqdn','uri','md5','sha1','sha256','sha512'];
 
+const RESULT_PARSERS = {
+    kaspersky: (info, statusElem, resultElem) => {
+        if(info.status_code !== 200){
+            statusElem.innerHTML = '<i class="fas fa-times"></i>';
+            statusElem.style.color = '#e74c3c';
+            resultElem.textContent = info.error || 'error';
+            return;
+        }
+        const res = info.data || {};
+        const zone = (res.zone || '').toLowerCase();
+        const zoneColors = {green:'#4caf50', yellow:'#f1c40f', red:'#e74c3c', grey:'#95a5a6'};
+        const valueElem = statusElem.parentElement.querySelector('.ioc-value');
+        if(valueElem && zoneColors[zone]) valueElem.style.color = zoneColors[zone];
+        if(zone && zone !== 'green') statusElem.dataset.malicious = 'true';
+        statusElem.innerHTML = '<i class="fas fa-check"></i>';
+        statusElem.style.color = zoneColors[zone] || '#4caf50';
+
+        const gen = res.general_info || {};
+        const parts = [];
+        if(res.zone) parts.push(`<span><i class="fas fa-shield-halved"></i> ${res.zone}</span>`);
+        if(gen.FileStatus) parts.push(`<span><i class="fas fa-bug"></i> ${gen.FileStatus}</span>`);
+        if(gen.Type) parts.push(`<span><i class="fas fa-file"></i> ${gen.Type}</span>`);
+        if(typeof gen.Size === 'number') parts.push(`<span><i class="fas fa-weight-hanging"></i> ${gen.Size}</span>`);
+        if(typeof gen.HitsCount === 'number') parts.push(`<span><i class="fas fa-bolt"></i> ${gen.HitsCount}</span>`);
+        if(gen.FirstSeen) parts.push(`<span><i class="fas fa-calendar-plus"></i> ${gen.FirstSeen}</span>`);
+        if(gen.LastSeen) parts.push(`<span><i class="fas fa-calendar-minus"></i> ${gen.LastSeen}</span>`);
+        if(gen.Sha256) parts.push(`<span><i class="fas fa-fingerprint"></i> ${gen.Sha256}</span>`);
+        resultElem.innerHTML = parts.join('<br>');
+    }
+};
+
 document.getElementById('provider').addEventListener('change', renderParsed);
 
 const fileInput = document.getElementById('file-input');
@@ -229,27 +260,9 @@ function poll(id, statusElem, resultElem){
             statusElem.style.color = '#999';
             setTimeout(() => poll(id, statusElem, resultElem), 1000);
         }else if(data.status === 'done'){
-            if(data.service === 'kaspersky'){
-                const info = data.result || {};
-                if(info.status_code !== 200){
-                    statusElem.innerHTML = '<i class="fas fa-times"></i>';
-                    statusElem.style.color = '#e74c3c';
-                    resultElem.textContent = info.error || 'error';
-                    return;
-                }
-                const res = info.data || {};
-                let text = `zone ${res.zone || 'unknown'}`;
-                if(res.status) text += `, status ${res.status}`;
-                if(typeof res.hits_count === 'number') text += `, hits ${res.hits_count}`;
-                if(res.categories && res.categories.length) text += `, categories ${res.categories.join(', ')}`;
-                const zone = (res.zone || '').toLowerCase();
-                const valueElem = statusElem.parentElement.querySelector('.ioc-value');
-                const zoneColors = {green:'#4caf50', yellow:'#f1c40f', red:'#e74c3c', grey:'#95a5a6'};
-                if(valueElem && zoneColors[zone]) valueElem.style.color = zoneColors[zone];
-                if(zone && zone !== 'green') statusElem.dataset.malicious = 'true';
-                statusElem.innerHTML = '<i class="fas fa-check"></i>';
-                statusElem.style.color = zoneColors[zone] || '#4caf50';
-                resultElem.textContent = text;
+            const parser = RESULT_PARSERS[data.service];
+            if(parser){
+                parser(data.result || {}, statusElem, resultElem);
             }else{
                 statusElem.innerHTML = '<i class="fas fa-times"></i>';
                 statusElem.style.color = '#e74c3c';

--- a/ioc_checker/templates/index.html
+++ b/ioc_checker/templates/index.html
@@ -158,12 +158,14 @@ const RESULT_PARSERS = {
         };
 
         const gen = res.general_info || {};
+        const skipKeys = new Set(['Domain','CategoriesWithZone','Sha1','Sha256','Md5','Sha512']);
         Object.entries(gen).forEach(([key, val]) => {
-            if(val === null || key === 'Domain' || key === 'CategoriesWithZone') return;
+            if(val === null || skipKeys.has(key)) return;
             if(key === 'Categories' && Array.isArray(val) && val.length){
-                let cat = val[0];
-                if(cat.includes('_')) cat = cat.split('_').slice(1).join(' ');
-                parts.push(`<span><i class="fas fa-tags"></i> ${short(cat)}</span>`);
+                val.forEach(cat => {
+                    if(cat.includes('_')) cat = cat.split('_').slice(1).join(' ');
+                    parts.push(`<span><i class="fas fa-tag"></i> ${short(cat)}</span>`);
+                });
                 return;
             }
             if(typeof val === 'string' || typeof val === 'number'){

--- a/ioc_checker/templates/index.html
+++ b/ioc_checker/templates/index.html
@@ -133,29 +133,45 @@ const RESULT_PARSERS = {
         statusElem.innerHTML = '<i class="fas fa-check"></i>';
         statusElem.style.color = zoneColors[zone] || '#4caf50';
 
-        const gen = res.general_info || {};
-        const parts = [];
         const short = v => typeof v === 'string' && v.length > 30 ? v.slice(0,27) + '...' : v;
-        if(info.type === 'domain'){
-            if(res.zone) parts.push(`<span><i class="fas fa-shield-halved"></i> ${res.zone}</span>`);
-            if(typeof gen.Ipv4Count === 'number') parts.push(`<span><i class="fas fa-network-wired"></i> ${gen.Ipv4Count}</span>`);
-            if(Array.isArray(gen.Categories) && gen.Categories.length){
-                let cat = gen.Categories[0];
+        const parts = [];
+        if(res.zone) parts.push(`<span><i class="fas fa-shield-halved"></i> ${res.zone}</span>`);
+
+        Object.entries({files_count:'fa-file', urls_count:'fa-link', hits_count:'fa-bolt', ipv4_count:'fa-network-wired'}).forEach(([key, icon]) => {
+            const val = res[key];
+            if(typeof val === 'number') parts.push(`<span><i class="fas ${icon}"></i> ${val}</span>`);
+        });
+
+        const iconMap = {
+            FileStatus: 'fa-bug',
+            Type: 'fa-file',
+            Size: 'fa-weight-hanging',
+            HitsCount: 'fa-bolt',
+            FirstSeen: 'fa-calendar-plus',
+            LastSeen: 'fa-calendar-minus',
+            Sha256: 'fa-fingerprint',
+            Sha1: 'fa-fingerprint',
+            Md5: 'fa-fingerprint',
+            Ipv4Count: 'fa-network-wired',
+            UrlsCount: 'fa-link',
+            FilesCount: 'fa-file'
+        };
+
+        const gen = res.general_info || {};
+        Object.entries(gen).forEach(([key, val]) => {
+            if(val === null || key === 'Domain' || key === 'CategoriesWithZone') return;
+            if(key === 'Categories' && Array.isArray(val) && val.length){
+                let cat = val[0];
                 if(cat.includes('_')) cat = cat.split('_').slice(1).join(' ');
                 parts.push(`<span><i class="fas fa-tags"></i> ${short(cat)}</span>`);
+                return;
             }
-            resultElem.innerHTML = parts.join(' ');
-            return;
-        }
-        if(res.zone) parts.push(`<span><i class="fas fa-shield-halved"></i> ${res.zone}</span>`);
-        if(gen.FileStatus) parts.push(`<span><i class="fas fa-bug"></i> ${gen.FileStatus}</span>`);
-        if(gen.Type) parts.push(`<span><i class="fas fa-file"></i> ${gen.Type}</span>`);
-        if(typeof gen.Size === 'number') parts.push(`<span><i class="fas fa-weight-hanging"></i> ${gen.Size}</span>`);
-        if(typeof gen.HitsCount === 'number') parts.push(`<span><i class="fas fa-bolt"></i> ${gen.HitsCount}</span>`);
-        if(gen.FirstSeen) parts.push(`<span><i class="fas fa-calendar-plus"></i> ${gen.FirstSeen}</span>`);
-        if(gen.LastSeen) parts.push(`<span><i class="fas fa-calendar-minus"></i> ${gen.LastSeen}</span>`);
-        if(gen.Sha256) parts.push(`<span><i class="fas fa-fingerprint"></i> ${short(gen.Sha256)}</span>`);
-        resultElem.innerHTML = parts.join('<br>');
+            if(typeof val === 'string' || typeof val === 'number'){
+                const icon = iconMap[key] || 'fa-circle';
+                parts.push(`<span><i class="fas ${icon}"></i> ${short(val)}</span>`);
+            }
+        });
+        resultElem.innerHTML = parts.join(' ');
     }
 };
 

--- a/ioc_checker/templates/index.html
+++ b/ioc_checker/templates/index.html
@@ -242,9 +242,13 @@ function poll(id, statusElem, resultElem){
                 if(res.status) text += `, status ${res.status}`;
                 if(typeof res.hits_count === 'number') text += `, hits ${res.hits_count}`;
                 if(res.categories && res.categories.length) text += `, categories ${res.categories.join(', ')}`;
-                if(res.zone && res.zone.toLowerCase() !== 'green') statusElem.dataset.malicious = 'true';
+                const zone = (res.zone || '').toLowerCase();
+                const valueElem = statusElem.parentElement.querySelector('.ioc-value');
+                const zoneColors = {green:'#4caf50', yellow:'#f1c40f', red:'#e74c3c', grey:'#95a5a6'};
+                if(valueElem && zoneColors[zone]) valueElem.style.color = zoneColors[zone];
+                if(zone && zone !== 'green') statusElem.dataset.malicious = 'true';
                 statusElem.innerHTML = '<i class="fas fa-check"></i>';
-                statusElem.style.color = '#4caf50';
+                statusElem.style.color = zoneColors[zone] || '#4caf50';
                 resultElem.textContent = text;
             }else{
                 statusElem.innerHTML = '<i class="fas fa-times"></i>';

--- a/ioc_checker/templates/index.html
+++ b/ioc_checker/templates/index.html
@@ -135,6 +135,18 @@ const RESULT_PARSERS = {
 
         const gen = res.general_info || {};
         const parts = [];
+        const short = v => typeof v === 'string' && v.length > 30 ? v.slice(0,27) + '...' : v;
+        if(info.type === 'domain'){
+            if(res.zone) parts.push(`<span><i class="fas fa-shield-halved"></i> ${res.zone}</span>`);
+            if(typeof gen.Ipv4Count === 'number') parts.push(`<span><i class="fas fa-network-wired"></i> ${gen.Ipv4Count}</span>`);
+            if(Array.isArray(gen.Categories) && gen.Categories.length){
+                let cat = gen.Categories[0];
+                if(cat.includes('_')) cat = cat.split('_').slice(1).join(' ');
+                parts.push(`<span><i class="fas fa-tags"></i> ${short(cat)}</span>`);
+            }
+            resultElem.innerHTML = parts.join(' ');
+            return;
+        }
         if(res.zone) parts.push(`<span><i class="fas fa-shield-halved"></i> ${res.zone}</span>`);
         if(gen.FileStatus) parts.push(`<span><i class="fas fa-bug"></i> ${gen.FileStatus}</span>`);
         if(gen.Type) parts.push(`<span><i class="fas fa-file"></i> ${gen.Type}</span>`);
@@ -142,7 +154,7 @@ const RESULT_PARSERS = {
         if(typeof gen.HitsCount === 'number') parts.push(`<span><i class="fas fa-bolt"></i> ${gen.HitsCount}</span>`);
         if(gen.FirstSeen) parts.push(`<span><i class="fas fa-calendar-plus"></i> ${gen.FirstSeen}</span>`);
         if(gen.LastSeen) parts.push(`<span><i class="fas fa-calendar-minus"></i> ${gen.LastSeen}</span>`);
-        if(gen.Sha256) parts.push(`<span><i class="fas fa-fingerprint"></i> ${gen.Sha256}</span>`);
+        if(gen.Sha256) parts.push(`<span><i class="fas fa-fingerprint"></i> ${short(gen.Sha256)}</span>`);
         resultElem.innerHTML = parts.join('<br>');
     }
 };

--- a/run.py
+++ b/run.py
@@ -16,6 +16,10 @@ from ioc_checker.main import app
 logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[%(levelname)s] %(name)s: %(message)s",
+    )
     config = Config()
     config.bind = ["127.0.0.1:8000"]
     config.use_reloader = True

--- a/tests/test_kaspersky.py
+++ b/tests/test_kaspersky.py
@@ -1,0 +1,40 @@
+import httpx
+
+from ioc_checker import kaspersky
+
+
+def test_parse_hash_only_first_seen():
+    data = {
+        "Zone": "Red",
+        "FileStatus": "Malware",
+        "Sha1": "a" * 40,
+        "Md5": "b" * 32,
+        "Sha256": "c" * 64,
+        "FirstSeen": "2024-01-01T00:00:00Z",
+        "LastSeen": "2024-01-02T00:00:00Z",
+        "Signer": "ACME",
+        "FileGeneralInfo": {},
+    }
+    parsed = kaspersky._parse_hash(data)
+    assert parsed["first_seen"] == "2024-01-01T00:00:00Z"
+    assert "last_seen" not in parsed
+
+
+def test_lookup_ip_uses_ip_param():
+    called = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:  # noqa: D401
+        called["url"] = str(request.url)
+        return httpx.Response(200, json={})
+
+    async def run() -> None:
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport, base_url="https://example.com") as client:
+            await kaspersky.lookup_ip("1.2.3.4", client)
+
+    import asyncio
+
+    asyncio.run(run())
+
+    assert "ip=1.2.3.4" in called["url"]
+


### PR DESCRIPTION
## Summary
- Replace Bulma-based UI with custom minimal styling and layout
- Show status icons to the left of each IOC and scan results to the right
- Add VirusTotal and Kaspersky link icons after each IOC text

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7fb67fcc0833380f3c745d60ed795