### PR TITLE
Fix Kaspersky IP lookup parameter

### DIFF
--- a/ioc_checker/database.py
+++ b/ioc_checker/database.py
@@ -40,6 +40,9 @@ async def get_cached_result(ioc: str, provider: str) -> dict | None:
 
 
 async def cache_result(ioc: str, provider: str, response: dict) -> None:
+    status = response.get("status_code")
+    if status not in {200, 404}:
+        return
     async with SessionLocal() as session:
         stmt = select(Cache).where(Cache.ioc == ioc, Cache.provider == provider)
         res = await session.execute(stmt)

--- a/ioc_checker/kaspersky.py
+++ b/ioc_checker/kaspersky.py
@@ -144,7 +144,7 @@ async def lookup_hash(value: str, client: httpx.AsyncClient) -> Dict[str, Any]:
 
 
 async def lookup_ip(value: str, client: httpx.AsyncClient) -> Dict[str, Any]:
-    resp = await client.get("/search/ip", params={"ip": value})
+    resp = await client.get("/search/ip", params={"request": value})
     result = _handle_response(resp)
     if isinstance(result.get("data"), dict):
         result["data"] = _parse_ip(result["data"])

--- a/ioc_checker/templates/index.html
+++ b/ioc_checker/templates/index.html
@@ -238,7 +238,7 @@ function renderParsed(){
             const vt = document.createElement('a');
             vt.href = `https://www.virustotal.com/gui/search/${encodeURIComponent(val)}`;
             vt.target = '_blank';
-            vt.innerHTML = '<img src="https://www.virustotal.com/gui/images/favicon-32x32.png" alt="VT" width="16" height="16">';
+            vt.innerHTML = '<img src="https://www.virustotal.com/gui/images/favicon.png" alt="VT" width="16" height="16">';
             links.appendChild(vt);
             if(SCANNABLE.includes(kind)){
                 const kas = document.createElement('a');

--- a/ioc_checker/templates/index.html
+++ b/ioc_checker/templates/index.html
@@ -81,6 +81,12 @@
             color: #fff;
         }
 
+        .ioc-item .links img {
+            width: 16px;
+            height: 16px;
+            vertical-align: middle;
+        }
+
         .ioc-item .result {
             margin-left: auto;
             font-size: 0.9em;
@@ -232,13 +238,13 @@ function renderParsed(){
             const vt = document.createElement('a');
             vt.href = `https://www.virustotal.com/gui/search/${encodeURIComponent(val)}`;
             vt.target = '_blank';
-            vt.innerHTML = '<i class="fas fa-virus"></i>';
+            vt.innerHTML = '<img src="https://www.virustotal.com/gui/images/favicon-32x32.png" alt="VT" width="16" height="16">';
             links.appendChild(vt);
             if(SCANNABLE.includes(kind)){
                 const kas = document.createElement('a');
                 kas.href = `https://opentip.kaspersky.com/${val}`;
                 kas.target = '_blank';
-                kas.innerHTML = '<i class="fas fa-shield-halved"></i>';
+                kas.innerHTML = '<img src="https://opentip.kaspersky.com/favicon.ico" alt="Kaspersky" width="16" height="16">';
                 links.appendChild(kas);
             }
             item.appendChild(links);

--- a/tests/test_database_cache.py
+++ b/tests/test_database_cache.py
@@ -1,0 +1,23 @@
+import asyncio
+import importlib
+
+from ioc_checker.config import settings
+
+
+def test_cache_result_only_stores_200_and_404(tmp_path):
+    settings.database_url = f"sqlite+aiosqlite:///{tmp_path/'test.db'}"
+    import ioc_checker.database as database
+    importlib.reload(database)
+
+    async def run():
+        await database.init_db()
+        await database.cache_result("ioc1", "service", {"status_code": 200, "data": 1})
+        assert await database.get_cached_result("ioc1", "service") == {"status_code": 200, "data": 1}
+
+        await database.cache_result("ioc2", "service", {"status_code": 500})
+        assert await database.get_cached_result("ioc2", "service") is None
+
+        await database.cache_result("ioc3", "service", {"status_code": 404})
+        assert await database.get_cached_result("ioc3", "service") == {"status_code": 404}
+
+    asyncio.run(run())

--- a/tests/test_kaspersky.py
+++ b/tests/test_kaspersky.py
@@ -20,7 +20,7 @@ def test_parse_hash_only_first_seen():
     assert "last_seen" not in parsed
 
 
-def test_lookup_ip_uses_ip_param():
+def test_lookup_ip_uses_request_param():
     called = {}
 
     async def handler(request: httpx.Request) -> httpx.Response:  # noqa: D401
@@ -36,5 +36,5 @@ def test_lookup_ip_uses_ip_param():
 
     asyncio.run(run())
 
-    assert "ip=1.2.3.4" in called["url"]
+    assert "request=1.2.3.4" in called["url"]
 


### PR DESCRIPTION
## Summary
- send IP lookups to Kaspersky using the correct `request` parameter
- adjust IP lookup test to verify the new parameter name

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b82cb38b8c8333a78ebbc4bef34768