### PR TITLE
feat: add GUI token storage for Kaspersky

### DIFF
--- a/ioc_checker/kaspersky.py
+++ b/ioc_checker/kaspersky.py
@@ -37,10 +37,11 @@ def classify_ioc(ioc: str) -> str:
 
 
 @asynccontextmanager
-async def get_context() -> AsyncIterator[httpx.AsyncClient]:
+async def get_context(token: str | None = None) -> AsyncIterator[httpx.AsyncClient]:
     headers = {}
-    if settings.kaspersky_token:
-        headers["x-api-key"] = settings.kaspersky_token
+    tok = token or settings.kaspersky_token
+    if tok:
+        headers["x-api-key"] = tok
     async with httpx.AsyncClient(base_url=API_BASE, headers=headers, timeout=10) as client:
         yield client
 

--- a/ioc_checker/main.py
+++ b/ioc_checker/main.py
@@ -36,6 +36,7 @@ NORMALIZE_KIND = {
 class ScanRequest(BaseModel):
     iocs: list[str]
     service: str = settings.providers[0]
+    kaspersky_token: str | None = None
 
 
 class ParseRequest(BaseModel):
@@ -101,7 +102,7 @@ async def scan(req: ScanRequest) -> dict:
     for ioc in req.iocs:
         if not ioc:
             continue
-        task_id = await add_task(ioc, req.service)
+        task_id = await add_task(ioc, req.service, req.kaspersky_token)
         task_ids.append({"id": task_id, "ioc": ioc, "service": req.service})
     return {"tasks": task_ids}
 

--- a/ioc_checker/queue.py
+++ b/ioc_checker/queue.py
@@ -14,6 +14,7 @@ class Task:
     status: str = "queued"  # queued, processing, done, error
     result: Optional[dict] = None
     error: Optional[str] = None
+    token: Optional[str] = None
 
 # In-memory storage
 _tasks: Dict[str, Task] = {}
@@ -22,9 +23,9 @@ queue: asyncio.Queue[str] = asyncio.Queue()
 logger = logging.getLogger(__name__)
 
 
-async def add_task(ioc: str, service: str = settings.providers[0]) -> str:
+async def add_task(ioc: str, service: str = settings.providers[0], token: Optional[str] = None) -> str:
     task_id = str(uuid.uuid4())
-    task = Task(id=task_id, ioc=ioc, service=service)
+    task = Task(id=task_id, ioc=ioc, service=service, token=token)
     _tasks[task_id] = task
     await queue.put(task_id)
     logger.info("Queued task %s for %s", task_id, service)

--- a/ioc_checker/templates/index.html
+++ b/ioc_checker/templates/index.html
@@ -111,6 +111,13 @@
             {% endfor %}
         </select>
     </div>
+    <details id="advanced-settings">
+        <summary>Advanced Settings</summary>
+        <div>
+            <label for="kaspersky-token">Kaspersky API token</label>
+            <input type="password" id="kaspersky-token" placeholder="API token">
+        </div>
+    </details>
     <div>
         <button id="scan-all">Scan all</button>
         <button id="copy-malicious">Copy malicious</button>
@@ -120,6 +127,13 @@
 
 <script>
 let parsedData = {};
+const tokenInput = document.getElementById('kaspersky-token');
+if(tokenInput){
+    tokenInput.value = localStorage.getItem('kaspersky_token') || '';
+    tokenInput.addEventListener('input', () => {
+        localStorage.setItem('kaspersky_token', tokenInput.value);
+    });
+}
 const SCANNABLE = ['ipv4','ipv6','fqdn','uri','md5','sha1','sha256','sha512'];
 
 const RESULT_PARSERS = {
@@ -268,7 +282,12 @@ function renderParsed(){
 function scan(iocs){
     if(!iocs.length) return;
     const service = document.getElementById('provider').value;
-    fetch('/scan', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({service, iocs})})
+    const body = {service, iocs};
+    const token = localStorage.getItem('kaspersky_token');
+    if(service === 'kaspersky' && token){
+        body.kaspersky_token = token;
+    }
+    fetch('/scan', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body)})
         .then(r => r.json())
         .then(data => {
             data.tasks.forEach(t => {


### PR DESCRIPTION
## Summary
- allow configuring Kaspersky API token from the web UI
- persist token in browser and send with scan requests
- update backend to accept per-request Kaspersky tokens

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b835d497bc8333bb50f22ed2b7afbe